### PR TITLE
 Added cluster-based permutation testing over timeseries

### DIFF
--- a/LFPAnalysis/statistics_utils.py
+++ b/LFPAnalysis/statistics_utils.py
@@ -190,7 +190,7 @@ def time_resolved_regression_single_channel(timeseries=None, regressors=None,
         all_res['ts'] = all_res['ts'] * (1000/sr)
 
     if ts_index is not None:
-        all_res['time'] = ts_index #[ts_index[int(t)] for t in all_res.ts]
+        all_res['time'] = [ts_index[int(t*(sr/1000))] for t in ts['ts'].values]
     
     return all_res
 

--- a/LFPAnalysis/statistics_utils.py
+++ b/LFPAnalysis/statistics_utils.py
@@ -113,7 +113,7 @@ def permutation_regression_zscore(data, formula, n_permutations=1000, plot_res=F
     return results
 
 def time_resolved_regression_single_channel(timeseries=None, regressors=None, 
-                             win_len=100, slide_len=25,
+                             win_len=100, slide_len=25, ts_index=None,
                              standardize=True, smooth=False, permute=False, sr=500):
     """
     In this function, if you provide a 2D array of z-scored time-varying neural data and a sert of regressors, 
@@ -189,6 +189,9 @@ def time_resolved_regression_single_channel(timeseries=None, regressors=None,
     else:
         all_res['ts'] = all_res['ts'] * (1000/sr)
 
+    if ts_index is not None:
+        all_res['time'] = ts_index #[ts_index[int(t)] for t in all_res.ts]
+    
     return all_res
 
 # def time_resolved_regression_perm(timeseries=None, regressors=None, win_len=100, slide_len=25, standardize=True, sr=None, nsurr=500):


### PR DESCRIPTION
Based on the large DataFrame of time-resolved regression coefficients generated across all electrodes using `statistics_utils.time_resolved_regression_single_channel(timeseries, regressors, standardize=True, smooth=False)`, can subselect rows for a given region of interest (e.g., 'AMY"):
 ```
roi_df = all_channels_df[all_channels_df.region == 'AMY'][['Original_Estimate', 'ts']]
```

Can run the following: `roi_ttest, cluster_tstats = cluster_based_permutation(roi_df)`, which produces the following outputs:
    - `roi_ttest`: DataFrame with t-statistics and p-values for each timepoint.
    - `cluster_tstats`: DataFrame with summed t-statistics and timepoint range for each cluster identified.

`cluster_based_permutation()` relies on the following dependencies:
- `find_clusters()`
- `ts_permutation_test()` and `ts_permutation_test()`

It also depends on the following packages: `pandas`, `numpy`, `scipy.stats.ttest_1samp`, `scipy.ndimage.label`, `joblib.Parallel`, `joblib.delayed`), `tqdm.tqdm`